### PR TITLE
Potential fix for code scanning alert no. 6: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const passport = require('passport');
 const passportLocalMongoose = require('passport-local-mongoose');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const findOrCreate = require('mongoose-findorcreate');
+const lusca = require('lusca');
 
 const app = express();
 
@@ -20,6 +21,8 @@ app.use(session({
     resave: false,
     saveUninitialized: false
 }));
+
+app.use(lusca.csrf());
 
 app.use(passport.initialize());
 app.use(passport.session());

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
-    "passport-local-mongoose": "^6.1.0"
+    "passport-local-mongoose": "^6.1.0",
+    "lusca": "^1.7.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Potential fix for [https://github.com/chawlajay/secrets-app/security/code-scanning/6](https://github.com/chawlajay/secrets-app/security/code-scanning/6)

In general, to fix missing CSRF protection in an Express app that uses cookie-based sessions, you should add a CSRF middleware (such as `lusca.csrf` or `csurf`) after you configure sessions and before defining state-changing routes, then ensure that your forms or AJAX clients send the CSRF token with every unsafe request (POST/PUT/PATCH/DELETE). The middleware will generate and validate a per-session secret token, blocking forged requests that lack or have an invalid token.

For this codebase, the least disruptive fix is to add `lusca` CSRF middleware right after `app.use(session(...))`, as CodeQL’s recommendation suggests, and leave all existing route logic unchanged. Specifically:

- Add a `lusca` import at the top of `app.js` (e.g., `const lusca = require('lusca');`).
- After the existing `app.use(session({...}))` call (line 18–22), add `app.use(lusca.csrf());`.
- Optionally, in views like the EJS template for `/submit`, `/register`, and `/login`, you would need to embed the CSRF token (for example via `res.locals._csrf` if using `lusca`) into a hidden form field or header. However, these templates are not shown, and we are constrained to only change the provided snippet in `app.js`. So the code change here is limited to enabling the middleware; template adjustments would be a follow-up task outside this snippet.

Concretely, in `app.js`:

- Insert `const lusca = require('lusca');` alongside the other `require` statements.
- Insert `app.use(lusca.csrf());` immediately after the session middleware block (lines 18–22), so that all subsequent routes, including the POST `/submit` handler on line 114, are protected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
